### PR TITLE
Updated build.gradle file

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -26,6 +26,6 @@ android {
 }
 
 dependencies {
-  compileOnly "com.facebook.react:react-native:+"
-  implementation 'com.airbnb.android:lottie:2.5.5'
+  provided "com.facebook.react:react-native:+"
+  compile 'com.airbnb.android:lottie:2.5.5'
 }


### PR DESCRIPTION
Before change, this script caused a "Could not find method compileOnly()" and "Could not find method implementation()" when performing react-native run-android. (RN version 0.55.4)